### PR TITLE
release: 0.1.48 fix nexus docker and npmjs groups

### DIFF
--- a/charts/nexus/Chart.yaml
+++ b/charts/nexus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: nexus
-version: 0.1.47
+version: 0.1.48
 icon: https://raw.githubusercontent.com/jenkins-x/jenkins-x-platform/master/jenkins-x-platform/images/nexus.png
 home: https://github.com/softtechconsulting/nexus

--- a/charts/nexus/values.yaml
+++ b/charts/nexus/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: austinfath/nexus
-  tag: 3.37.3
+  tag: 3.37.4
   pullPolicy: IfNotPresent
 service:
   name: nexus

--- a/docker-group-repositories/docker-group.json
+++ b/docker-group-repositories/docker-group.json
@@ -6,13 +6,12 @@
     "strictContentTypeValidation": true
   },
   "group": {
-    "memberNames": ["docker-proxy", "docker-internal"],
-    "writableMember": "docker-internal"
+    "memberNames": ["docker-proxy", "docker-internal"]
   },
   "docker": {
     "v1Enabled": false,
     "forceBasicAuth": true,
-    "httpPort": 8082,
-    "httpsPort": 8083
+    "httpPort": 8086,
+    "httpsPort": 8087
   }
 }

--- a/postStart.sh
+++ b/postStart.sh
@@ -99,7 +99,7 @@ done
 echo "Creating npmjs group repositories from json"
 mapfile -t REPOS < <(find "${NEXUS_NPMJS_GROUP_DIR}" -maxdepth 1 -type f -name "*json*")
 for repo in "${REPOS[@]}"; do
-    runCurlFromJsonFile "${repo}" "service/rest/v1/repositories/npmjs/group" POST
+    runCurlFromJsonFile "${repo}" "service/rest/v1/repositories/npm/group" POST
 done
 
 # For each maven group repository json file, create the repo via the Nexus API.


### PR DESCRIPTION
- build and push custom nexus docker image
- remove docker group write due to missing license
- fix docker group ports
- fix npmjs group api path
- update chart version 0.1.48